### PR TITLE
Sym Link `pop-tail-proxy-log` and `pop-format-log` to `/usr/local/bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 ports.yml
 settings.js
 log
+bin/pop-tail-proxy-log
 templates/generated/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ ports.yml
 settings.js
 log
 bin/pop-tail-proxy-log
+bin/pop-tail-dns-log
 templates/generated/*

--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ An example file is written to `ports.yml` and excluded from version control. Mod
 
 ## Logging
 ---
-One of the chief advantages of using Pop is its dynamic logging. The log file is kept at `log/pop_proxy.log`. A node script to read the log called `formatLog` exists in the root directory of the repo.
+One of the chief advantages of using Pop is its dynamic logging. Both the Dns and Proxy server log to `log/dns.log` and `log/proxy.log` respectively.
+
+## /usr/local/bin
+3 scripts are linked into /usr/local/bin to make reading the logs easier: `pop-tail-proxy-log`, `pop-tail-dns-log`, and `pop-format-log`. You can run `pop-tail-proxy-log | pop-format-log` for fancified logs.

--- a/bin/pop-format-log
+++ b/bin/pop-format-log
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+var readline = require('readline'),
+  colors = require('colors'),
+  _ = require('lodash'),
+  prettyjson = require('prettyjson'),
+  moment = require('moment')
+
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+});
+
+rl.on('line', function(line){
+  log = JSON.parse(line)
+  console.log(summaryString(log))
+})
+
+var allColors = {
+  0: 'red',
+  1: 'grey',
+  2: 'cyan',
+  3: 'grey',
+  4: 'green',
+  5: 'grey',
+  6: 'cyan',
+  7: 'yellow',
+  8: 'blue',
+  9: 'rainbow'
+}
+
+function summaryString(log) {
+  if(!log.type || !log.port) return log
+
+  var portColor = allColors[(log.port || 0) % 10]
+
+  if(log.type == 'response') {
+    var topLine = log.uuid + ' @' + moment(log.time).format('hh:ss:SSS') + ' ' + log.statusCode + ' ' +  log.method + ' [' + log.port + '] ' + log.host + '' + log.url
+    var extra = prettyjson.render(extraDetails(log.responseBody, log.responseHeaders), { noColor: true})
+    return colors[portColor](topLine + '\n' + extra + '\n').inverse
+  } else if(log.type == 'error') {
+    var topLine = log.uuid + ' @' + moment(log.time).format('hh:ss:SSS') + ' ' + log.method + ' [' + log.port + '] ' + log.host + '' + log.url
+    var extra = prettyjson.render(extraDetails(log.body, log.headers), { noColor: true})
+    var error = prettyjson.render(log.error, { noColor: true})
+    return (topLine + '\n' + extra + '\n' + error.red + '\n').inverse
+  } else if(log.type == 'request') {
+    var topLine = log.uuid + ' @' + moment(log.time).format('hh:ss:SSS') + ' ' + log.method + ' [' + log.port + '] ' + log.host + '' + log.url
+    var extra = prettyjson.render(extraDetails(log.body, log.headers), { noColor: true})
+    return colors[portColor](topLine + '\n' + extra + '\n')
+  } else {
+    return log
+  }
+}
+
+function extraDetails(body, headers) {
+  if(body && !_.isEmpty(body)) {
+    return {
+      body: body,
+      headers: headers
+    }
+  }
+  return { headers: headers }
+}
+

--- a/install.sh
+++ b/install.sh
@@ -49,3 +49,7 @@ then
   sudo rm /etc/resolver/dev
 fi
 sudo cp $TEMPLATES/dev /etc/resolver/
+
+echo "tail -f $PWD/log/proxy.log" >> bin/pop-tail-proxy-log
+chmod +x bin/pop-tail-proxy-log
+ln -sfv $PWD/bin/pop-* /usr/local/bin

--- a/install.sh
+++ b/install.sh
@@ -51,5 +51,7 @@ fi
 sudo cp $TEMPLATES/dev /etc/resolver/
 
 echo "tail -f $PWD/log/proxy.log" >> bin/pop-tail-proxy-log
+echo "tail -f $PWD/log/dns.log" >> bin/pop-tail-dns-log
 chmod +x bin/pop-tail-proxy-log
+chmod +x bin/pop-tail-dns-log
 ln -sfv $PWD/bin/pop-* /usr/local/bin

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,4 +7,6 @@ sudo launchctl unload ~/Library/LaunchAgents/github.jdalt.pop.*
 sudo rm ~/Library/LaunchAgents/github.jdalt.pop.*
 sudo rm $TEMPLATES/*
 sudo rm /etc/resolver/dev
-rm /usr/local/bin/pop-*
+rm /usr/local/bin/pop-format-log
+rm /usr/local/bin/pop-tail-proxy-log
+rm /usr/local/bin/pop-tail-dns-log

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,3 +7,4 @@ sudo launchctl unload ~/Library/LaunchAgents/github.jdalt.pop.*
 sudo rm ~/Library/LaunchAgents/github.jdalt.pop.*
 sudo rm $TEMPLATES/*
 sudo rm /etc/resolver/dev
+rm /usr/local/bin/pop-*


### PR DESCRIPTION
Gives us a way to automatically generate symlinks that are always accessible on the terminal.