### PR TITLE
Add log rotation each hour since it only works if the computer is awake

### DIFF
--- a/dns.js
+++ b/dns.js
@@ -9,8 +9,10 @@ var log = bunyan.createLogger({
     level: 'trace',
     stream: process.stdout
   },{
+    type: 'rotating-file',
     level: 'info',
-    path: path.resolve(__dirname, 'log/dns.log')
+    path: path.resolve(__dirname, 'log/dns.log'),
+    period: '1h'
   }]
 })
 

--- a/lib/proxy-kit.js
+++ b/lib/proxy-kit.js
@@ -12,8 +12,10 @@ var log = bunyan.createLogger({
     level: 'trace',
     stream: process.stdout
   },{
+    type: 'rotating-file',
     level: 'info',
-    path: path.resolve(__dirname, '../log/proxy.log')
+    path: path.resolve(__dirname, '../log/proxy.log'),
+    period: '1h'
   }]
 })
 


### PR DESCRIPTION
Add log rotation for the proxy and dns logs.
Rotates every hour since it will only rotate if the service is running and your computer is awake.
By default it keeps 10 periods (10 hours in our case).