### PR TITLE
Follow logs by name vs file pointer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,8 +50,8 @@ then
 fi
 sudo cp $TEMPLATES/dev /etc/resolver/
 
-echo "tail -f $PWD/log/proxy.log" >> bin/pop-tail-proxy-log
-echo "tail -f $PWD/log/dns.log" >> bin/pop-tail-dns-log
+echo "tail -F $PWD/log/proxy.log" >> bin/pop-tail-proxy-log
+echo "tail -F $PWD/log/dns.log" >> bin/pop-tail-dns-log
 chmod +x bin/pop-tail-proxy-log
 chmod +x bin/pop-tail-dns-log
 ln -sfv $PWD/bin/pop-* /usr/local/bin


### PR DESCRIPTION
We are rotating our logs, so tailing logs by name rather than file pointer seems more appropriate.