### PR TITLE
overwrite rather than append tail scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,8 +50,8 @@ then
 fi
 sudo cp $TEMPLATES/dev /etc/resolver/
 
-echo "tail -F $PWD/log/proxy.log" >> bin/pop-tail-proxy-log
-echo "tail -F $PWD/log/dns.log" >> bin/pop-tail-dns-log
+echo "tail -F $PWD/log/proxy.log" > bin/pop-tail-proxy-log
+echo "tail -F $PWD/log/dns.log" > bin/pop-tail-dns-log
 chmod +x bin/pop-tail-proxy-log
 chmod +x bin/pop-tail-dns-log
 ln -sfv $PWD/bin/pop-* /usr/local/bin


### PR DESCRIPTION
The tail scripts should overwrite rather than append so that the `uninstall` and `install` process can be run multiple times.