### PR TITLE
Body logging by port

### DIFF
--- a/lib/proxy-kit.js
+++ b/lib/proxy-kit.js
@@ -81,8 +81,7 @@ module.exports = function proxyKit() {
   }
 
   function shouldLogResponseBody(req) {
-    return settings.log.responseBody ||
-          settings.ports[req.pop.port] && settings.ports[req.pop.port].log && settings.ports[req.pop.port].log.responseBody
+    return settings.log.responseBody || _.get(settings, 'ports[' + req.pop.port + '].log.responseBody')
   }
 
   const portsYml = path.resolve(__dirname, '../config/ports.yml')

--- a/lib/proxy-kit.js
+++ b/lib/proxy-kit.js
@@ -82,7 +82,7 @@ module.exports = function proxyKit() {
 
   function shouldLogResponseBody(req) {
     return settings.log.responseBody ||
-          settings.apps[req.pop.port] && settings.apps[req.pop.port].log && settings.apps[req.pop.port].log.responseBody
+          settings.ports[req.pop.port] && settings.ports[req.pop.port].log && settings.ports[req.pop.port].log.responseBody
   }
 
   const portsYml = path.resolve(__dirname, '../config/ports.yml')

--- a/lib/proxy-kit.js
+++ b/lib/proxy-kit.js
@@ -31,7 +31,7 @@ module.exports = function proxyKit() {
     })
 
     proxy.on('proxyRes', function(proxyRes, req, res, options) {
-      if (settings.log.responseBody && !proxyRes.headers['content-encoding']) {
+      if (shouldLogResponseBody(req) && !proxyRes.headers['content-encoding']) {
         var proxyResBody = ''
         proxyRes.on('data', function(data) { proxyResBody += data })
         proxyRes.on('end', function() {
@@ -78,6 +78,11 @@ module.exports = function proxyKit() {
 
   function handleRequest(req, res) {
     proxy.web(req, res, { target: getDomain(req, res) })
+  }
+
+  function shouldLogResponseBody(req) {
+    return settings.log.responseBody ||
+          settings.apps[req.pop.port] && settings.apps[req.pop.port].log && settings.apps[req.pop.port].log.responseBody
   }
 
   const portsYml = path.resolve(__dirname, '../config/ports.yml')

--- a/templates/settings_example.js
+++ b/templates/settings_example.js
@@ -1,5 +1,12 @@
 module.exports = {
   "log": {
     "responseBody": false,
+  },
+  "apps": {
+    3001: {
+      "log": {
+        "responseBody": false
+      }
+    }
   }
 }

--- a/templates/settings_example.js
+++ b/templates/settings_example.js
@@ -2,7 +2,7 @@ module.exports = {
   "log": {
     "responseBody": false,
   },
-  "apps": {
+  "ports": {
     3001: {
       "log": {
         "responseBody": false


### PR DESCRIPTION
Allows you to specify body logging by port. Trim down your log size some. Added an example format in the settings example.